### PR TITLE
Port 1252 broken commerce hub documentation links 

### DIFF
--- a/config/document-explorer-definition.yaml
+++ b/config/document-explorer-definition.yaml
@@ -69,7 +69,6 @@
       link: docs/Resources/API-Documents/Payments_VAS/Payment-Token.md
     - title: Glossary
       link: docs/Resources/FAQs-Glossary/Glossary.md
-
 - sections:
   - title: API Reference
     sections:

--- a/config/document-explorer-definition.yaml
+++ b/config/document-explorer-definition.yaml
@@ -69,6 +69,8 @@
       link: docs/Resources/API-Documents/Payments_VAS/Payment-Token.md
     - title: Glossary
       link: docs/Resources/FAQs-Glossary/Glossary.md
+    - title: Processor Response Parameters
+      links: docs/Resources/Master-Data/Processor-Response-Details.md
 - sections:
   - title: API Reference
     sections:

--- a/config/document-explorer-definition.yaml
+++ b/config/document-explorer-definition.yaml
@@ -69,8 +69,7 @@
       link: docs/Resources/API-Documents/Payments_VAS/Payment-Token.md
     - title: Glossary
       link: docs/Resources/FAQs-Glossary/Glossary.md
-    - title: Processor Response Parameters
-      links: docs/Resources/Master-Data/Processor-Response-Details.md
+
 - sections:
   - title: API Reference
     sections:

--- a/docs/Resources/Master-Data/Processor-Response-Details.md
+++ b/docs/Resources/Master-Data/Processor-Response-Details.md
@@ -198,7 +198,7 @@ title: JSON Example
 ---
 
 ## See Also
-- [API Explorer](../api/?type=post&path=/payments/v1/charges)
+- [API Explorer](https://dev-developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments/v1/charges)
 - [Address Verification](?path=docs/Resources/Guides/Fraud/Address-Verification.md)
 - [Gateway Response Codes](?path=docs/Resources/Guides/Response-Codes/Gateway.md)
 - [Gateway Response](?path=docs/Resources/Master-Data/Gateway-Response.md)


### PR DESCRIPTION
Fixed API Explorer link to be https://dev-developer.fiserv.com/product/CommerceHub/api/?type=post&path=/payments/v1/charges @TaniaSarkar89 @acho-fiserv